### PR TITLE
make clFFT useable for lalsuite

### DIFF
--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -6,18 +6,18 @@
 from spack import *
 
 
-class Clfft(CMakePackage):
+class Clfft(CMakePackage, CudaPackage):
     """a software library containing FFT functions written in OpenCL"""
 
     homepage = "https://github.com/clMathLibraries/clFFT"
-    url      = "https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz"
+    git      = "https://github.com/bema-aei/clFFT.git"
 
-    version('2.12.2', '9104d85f9f2f3c58dd8efc0e4b06496f')
+    version("2.12.2", commit="de4cab2ec2a90078b827f9a480a446a009637f61")
 
-    variant('client', default=True,
+    variant('client', default=False,
             description='build client and callback client')
+    variant("cuda", default=True, description="Build with CUDA-openCL")
 
-    depends_on('opencl@1.2:')
     depends_on('boost@1.33.0:', when='+client')
 
     root_cmakelists_dir = 'src'


### PR DESCRIPTION
The current clFFT package is not working on the atlasnodes with lalsuite, because

* it depends on pocl which falis to compile and is may relateted to https://github.com/spack/spack/issues/7460 
*  we need to modify the header file of clFFT as it not compatible with standard c in one prototype

Thus I remove the pocl dependencies, which is by now the only one, which provides OpenCL afaik ( in terms of `spack providers opencl`) and add the CudaPackage as base package for OpenCL.  
Also I use [this branch](https://github.com/bema-aei/clFFT/tree/C-interface) from bernd, which he also uses for the e@h builds to have a standard c compatible header file.