### PR TITLE
ocl-icd: fix build with missing docbook xml catalogs

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc-py3/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc-py3/package.py
@@ -23,3 +23,5 @@ class AsciidocPy3(AutotoolsPackage):
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('libxml2',     type=('build', 'run'))
     depends_on('libxslt',     type=('build', 'run'))
+    depends_on('docbook-xml', type=('build', 'run'))
+    depends_on('docbook-xsl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -20,6 +20,14 @@ class DocbookXml(Package):
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
+    @property
+    def catalog(self):
+        return os.path.join(self.prefix, 'catalog.xml')
+
     def setup_run_environment(self, env):
-        catalog = os.path.join(self.prefix, 'catalog.xml')
+        catalog = self.catalog
         env.set('XML_CATALOG_FILES', catalog, separator=' ')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        catalog = self.catalog
+        env.set("XML_CATALOG_FILES", catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -28,8 +28,8 @@ class DocbookXsl(Package):
 
     def setup_run_environment(self, env):
         catalog = self.catalog
-        env.set('XML_CATALOG_FILES', catalog, separator=' ')
+        env.prepend_path('XML_CATALOG_FILES', catalog, separator=' ')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         catalog = self.catalog
-        env.prepend_path("XML_CATALOG_FILES", catalog)
+        env.prepend_path("XML_CATALOG_FILES", catalog, separator=' ')


### PR DESCRIPTION
This  PR contains the cherry-picked commit from my upstream fixes